### PR TITLE
feat: 구장 페이지 지도 구현

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,7 +9,7 @@ module.exports = {
     'import/resolver': {
       node: {
         paths: ['src'],
-        "extensions": [".js", ".jsx", ".ts", ".tsx"] 
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
       },
     },
   },
@@ -21,7 +21,8 @@ module.exports = {
       { allowConstantExport: true },
     ],
     'no-restricted-exports': 'off',
-    "import/no-unresolved": "off",
+    'import/no-unresolved': 'off',
+    'import/prefer-default-export': 'off',
     'react/react-in-jsx-scope': 'off',
     'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
   },

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script
       type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=0c4a288da1632156fb806314e4372b97"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=0c4a288da1632156fb806314e4372b97&libraries=services"
     ></script>
 
     <title>Vite + React</title>

--- a/src/components/Header/Header.styled.js
+++ b/src/components/Header/Header.styled.js
@@ -17,8 +17,8 @@ export const HomeLink = styled.a`
   text-decoration: none;
 `
 export const Logo = styled.img`
-  width: 120px;
-  height: 120px;
+  width: 100px;
+  height: 100px;
 `
 
 export const Title = styled.div`

--- a/src/pages/MainPage/components/ClubSection/ClubSection.jsx
+++ b/src/pages/MainPage/components/ClubSection/ClubSection.jsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import * as S from './ClubSection.styled'
 
 const CLUB_INFO = [
@@ -15,11 +16,11 @@ function ClubSection() {
   return (
     <S.Container>
       {CLUB_INFO.map(club => (
-        <a href={`stadium/${club.link}`}>
+        <Link to={`stadium/${club.link}`} key={club.title}>
           <S.Item key={club.title}>
             <div>{club.title}</div>
           </S.Item>
-        </a>
+        </Link>
       ))}
     </S.Container>
   )

--- a/src/pages/MainPage/components/ClubSection/ClubSection.jsx
+++ b/src/pages/MainPage/components/ClubSection/ClubSection.jsx
@@ -5,11 +5,11 @@ const CLUB_INFO = [
   { title: '잠실 구장(서울)', link: 'jamsil' },
   { title: '사직 구장(부산)', link: 'busan' },
   { title: '라이온즈파크(대구)', link: 'daegu' },
-  { title: '이글스파크(대전)', link: 'daejaen' },
-  { title: '챔피언스필드(광주)', link: 'ghwangju' },
+  { title: '이글스파크(대전)', link: 'daejeon' },
+  { title: '챔피언스필드(광주)', link: 'gwangju' },
   { title: '랜더스필드(인천)', link: 'incheon' },
   { title: 'NC파크(창원)', link: 'changwon' },
-  { title: '고척 스카이돔(서울)', link: 'gochuck' },
+  { title: '고척 스카이돔(서울)', link: 'gocheok' },
 ]
 
 function ClubSection() {

--- a/src/pages/StadiumPage/StadiumPage.jsx
+++ b/src/pages/StadiumPage/StadiumPage.jsx
@@ -1,69 +1,10 @@
-import { Map, MapMarker } from 'react-kakao-maps-sdk'
-import React, { useState, useEffect } from 'react'
 import * as S from './StadiumPage.styled'
+import PickerMapSection from './components/PickerMapSection'
 
 function StadiumPage() {
-  const [state, setState] = useState({
-    center: {
-      lat: 33.450701,
-      lng: 126.570667,
-    },
-    errMsg: null,
-    isLoading: true,
-  })
-
-  useEffect(() => {
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        position => {
-          setState(prev => ({
-            ...prev,
-            center: {
-              lat: position.coords.latitude,
-              lng: position.coords.longitude,
-            },
-            isLoading: false,
-          }))
-        },
-        err => {
-          setState(prev => ({
-            ...prev,
-            errMsg: err.message,
-            isLoading: false,
-          }))
-        }
-      )
-    } else {
-      setState(prev => ({
-        ...prev,
-        errMsg: 'geolocation을 사용할수 없어요..',
-        isLoading: false,
-      }))
-    }
-  }, [])
-
   return (
     <S.Container>
-      <Map
-        center={state.center}
-        style={{
-          width: '80%',
-          height: '600px',
-          marginTop: '48px',
-        }}
-        level={3}
-      >
-        <MapMarker
-          position={state.center}
-          image={{
-            src: 'https://cdn-icons-png.flaticon.com/128/7124/7124723.png',
-            size: {
-              width: 50,
-              height: 50,
-            },
-          }}
-        />
-      </Map>
+      <PickerMapSection />
     </S.Container>
   )
 }

--- a/src/pages/StadiumPage/StadiumPage.styled.js
+++ b/src/pages/StadiumPage/StadiumPage.styled.js
@@ -1,14 +1,6 @@
 import styled from 'styled-components'
 
-export const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-
-  max-width: 1320px;
-  margin: 0 auto;
-  padding: 40px 0;
-`
+export const Container = styled.div``
 
 export const ClubImg = styled.img`
   display: flex;

--- a/src/pages/StadiumPage/StadiumPage.styled.js
+++ b/src/pages/StadiumPage/StadiumPage.styled.js
@@ -1,9 +1,5 @@
 import styled from 'styled-components'
 
-export const Container = styled.div``
-
-export const ClubImg = styled.img`
-  display: flex;
-  width: 300px;
-  margin: 0 auto;
+export const Container = styled.div`
+  display: block;
 `

--- a/src/pages/StadiumPage/components/PickerMapSection/PickerMapSection.jsx
+++ b/src/pages/StadiumPage/components/PickerMapSection/PickerMapSection.jsx
@@ -1,0 +1,73 @@
+import { Map, MapMarker } from 'react-kakao-maps-sdk'
+import React, { useState, useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+import * as S from './PickerMapSection.styled'
+import { getStadiumLocation } from '../../../../utils/getStadiumLocation'
+
+const { kakao } = window
+
+function PickerMapSection() {
+  const params = useParams()
+
+  const [locationState, setLocationState] = useState({
+    center: {
+      lat: 33.450701,
+      lng: 126.570667,
+    },
+    errMsg: null,
+    isLoading: true,
+  })
+
+  useEffect(() => {
+    const geocoder = new kakao.maps.services.Geocoder()
+
+    const callback = function (result, status) {
+      if (status === kakao.maps.services.Status.OK) {
+        const newSearch = result[0]
+
+        setLocationState({
+          center: {
+            lat: parseFloat(newSearch.y),
+            lng: parseFloat(newSearch.x),
+          },
+          isLoading: false,
+        })
+      } else {
+        setLocationState(prev => ({
+          ...prev,
+          errMsg: '주소 변환에 실패했어요.',
+          isLoading: false,
+        }))
+      }
+    }
+
+    geocoder.addressSearch(getStadiumLocation(params.stadiumName), callback)
+  }, [])
+
+  return (
+    <S.Container>
+      <Map
+        center={locationState.center}
+        style={{
+          width: '100%',
+          height: '600px',
+          marginTop: '48px',
+        }}
+        level={3}
+      >
+        <MapMarker
+          position={locationState.center}
+          image={{
+            src: 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_red.png',
+            size: {
+              width: 50,
+              height: 50,
+            },
+          }}
+        />
+      </Map>
+    </S.Container>
+  )
+}
+
+export default PickerMapSection

--- a/src/pages/StadiumPage/components/PickerMapSection/PickerMapSection.jsx
+++ b/src/pages/StadiumPage/components/PickerMapSection/PickerMapSection.jsx
@@ -8,6 +8,7 @@ const { kakao } = window
 
 function PickerMapSection() {
   const params = useParams()
+  const stadiumLocation = getStadiumLocation(params.stadiumName).location
 
   const [locationState, setLocationState] = useState({
     center: {
@@ -41,7 +42,7 @@ function PickerMapSection() {
       }
     }
 
-    geocoder.addressSearch(getStadiumLocation(params.stadiumName), callback)
+    geocoder.addressSearch(stadiumLocation, callback)
   }, [])
 
   return (

--- a/src/pages/StadiumPage/components/PickerMapSection/PickerMapSection.styled.js
+++ b/src/pages/StadiumPage/components/PickerMapSection/PickerMapSection.styled.js
@@ -1,0 +1,14 @@
+import styled from 'styled-components'
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 40px 0;
+`
+
+export const ClubImg = styled.img`
+  display: flex;
+`

--- a/src/pages/StadiumPage/components/PickerMapSection/PickerMapSection.styled.js
+++ b/src/pages/StadiumPage/components/PickerMapSection/PickerMapSection.styled.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 
 export const Container = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -11,4 +12,29 @@ export const Container = styled.div`
 
 export const ClubImg = styled.img`
   display: flex;
+`
+
+export const CategoryButtonSection = styled.div`
+  position: absolute;
+  display: flex;
+  gap: 20px;
+  z-index: 10;
+  top: 120px;
+  right: 30px;
+`
+
+export const Button = styled.button`
+  display: flex;
+  border: none;
+  background-color: #fff;
+  padding: 10px 18px;
+  border-radius: 20px;
+  font-size: 16px;
+  cursor: pointer;
+  transition: 0.3s;
+  &:hover {
+    box-shadow:
+      0px 2px 20px 0px rgba(0, 0, 0, 0.05),
+      0px 8px 32px 0px rgba(0, 0, 0, 0.1);
+  }
 `

--- a/src/pages/StadiumPage/components/PickerMapSection/index.js
+++ b/src/pages/StadiumPage/components/PickerMapSection/index.js
@@ -1,0 +1,1 @@
+export { default } from './PickerMapSection'

--- a/src/pages/StadiumPage/hooks/useGeocoding.js
+++ b/src/pages/StadiumPage/hooks/useGeocoding.js
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react'
+
+function useGeocoding(location) {
+  const { kakao } = window
+
+  const [locationState, setLocationState] = useState({
+    center: { lat: 33.450701, lng: 126.570667 },
+    errMsg: null,
+    isLoading: true,
+  })
+
+  useEffect(() => {
+    const geocoder = new kakao.maps.services.Geocoder()
+    const callback = (result, status) => {
+      if (status === kakao.maps.services.Status.OK) {
+        const newSearch = result[0]
+        setLocationState({
+          center: {
+            lat: parseFloat(newSearch.y),
+            lng: parseFloat(newSearch.x),
+          },
+          isLoading: false,
+        })
+      } else {
+        setLocationState(prev => ({
+          ...prev,
+          errMsg: '주소 변환에 실패했어요.',
+          isLoading: false,
+        }))
+      }
+    }
+    geocoder.addressSearch(location, callback)
+  }, [location])
+
+  return locationState
+}
+
+export default useGeocoding

--- a/src/pages/StadiumPage/hooks/useSearchPlaces.js
+++ b/src/pages/StadiumPage/hooks/useSearchPlaces.js
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+
+function useSearchPlaces(center) {
+  const [search, setSearch] = useState([])
+
+  const searchPlaces = keyword => {
+    const { kakao } = window
+    if (!center) return
+
+    const ps = new kakao.maps.services.Places()
+    const options = {
+      location: new kakao.maps.LatLng(center.lat, center.lng),
+      radius: 5000,
+      sort: kakao.maps.services.SortBy.DISTANCE,
+    }
+
+    ps.keywordSearch(
+      keyword,
+      (data, status) => {
+        if (status === kakao.maps.services.Status.OK) {
+          setSearch(data)
+        } else {
+          console.error('검색에 실패하였습니다.')
+        }
+      },
+      options
+    )
+  }
+
+  return { search, searchPlaces }
+}
+
+export default useSearchPlaces

--- a/src/redux/actions/counterAction.js
+++ b/src/redux/actions/counterAction.js
@@ -1,6 +1,6 @@
 // Action Types
-const ACTION_TYPE_INCREASE = 'increase'
-const ACTION_TYPE_DECREASE = 'decrease'
+export const ACTION_TYPE_INCREASE = 'increase'
+export const ACTION_TYPE_DECREASE = 'decrease'
 
 // Action Creators 작성하기
 export function increaseActionCreator() {

--- a/src/redux/reducers/counterReducer.js
+++ b/src/redux/reducers/counterReducer.js
@@ -1,7 +1,7 @@
 // Action Types import 하는 코드 작성
 import {
-  default as ACTION_TYPE_DECREASE,
-  default as ACTION_TYPE_INCREASE,
+  ACTION_TYPE_DECREASE,
+  ACTION_TYPE_INCREASE,
 } from '../actions/counterAction'
 
 // 초기 상태 작성
@@ -17,7 +17,7 @@ export const initialState = {
 // 2. 리듀서에 어떤 변화 줘야 할지 정의하기
 
 // Reducer 작성하기
-function counterReducer(state = initialState, action) {
+function counterReducer(action, state = initialState) {
   // action이 없는 경우 state 리턴하는 코드 작성
   if (!action) {
     return state

--- a/src/utils/constants/mapKeywordList.js
+++ b/src/utils/constants/mapKeywordList.js
@@ -1,0 +1,4 @@
+export const KEYWORD_LIST = [
+  { id: 1, value: ' 주차장', emoji: '🅿️' },
+  { id: 2, value: ' 근처 버스정류장', emoji: '🚌' },
+]

--- a/src/utils/getStadiumLocation.js
+++ b/src/utils/getStadiumLocation.js
@@ -1,0 +1,54 @@
+export const getStadiumLocation = stadiumName => {
+  switch (stadiumName) {
+    case 'daejeon':
+      return {
+        location: '대전광역시 중구 대종로 373',
+        lat: 36.3253,
+        lng: 127.4238,
+      }
+    case 'jamsil':
+      return {
+        location: '서울특별시 송파구 올림픽로 25',
+        lat: 37.5156,
+        lng: 127.0724,
+      }
+    case 'busan':
+      return {
+        location: '부산광역시 동래구 사직로 45',
+        lat: 35.1944,
+        lng: 129.0597,
+      }
+    case 'gwangju':
+      return {
+        location: '광주광역시 북구 서림로 10',
+        lat: 35.1858,
+        lng: 126.8523,
+      }
+    case 'daegu':
+      return {
+        location: '대구광역시 수성구 야구전설로 1',
+        lat: 35.8324,
+        lng: 128.6811,
+      }
+    case 'incheon':
+      return {
+        location: '인천광역시 미추홀구 매소홀로 618',
+        lat: 37.4363,
+        lng: 126.693,
+      }
+    case 'changwon':
+      return {
+        location: '경상남도 창원시 마산회원구 삼호로 63',
+        lat: 35.2193,
+        lng: 128.5833,
+      }
+    case 'gocheok':
+      return {
+        location: '서울특별시 구로구 경인로 430',
+        lat: 37.4982,
+        lng: 126.8679,
+      }
+    default:
+      return null
+  }
+}


### PR DESCRIPTION
- Close #1 

## What is this PR? 🔍

- 기능 : 구장페이지 지도 구현
- issue : #1

## Changes 📝

* 구장 페이지의 지도를 띄우고 마커를 찍는 기능을 추가하였습니다.
  * 구장에는 야구공 모양의 마커가 찍힙니다
  * 주차장과 근처 버스정류장 카테고리를 클릭하면 상황에 맞는 요소들이 지도위 마커가 찍힙니다.  

<!-- 이번 PR에서의 변경점 -->

## ScreenShot 📷

<img width="1146" alt="image" src="https://github.com/user-attachments/assets/9a1d52bd-a102-4583-80a6-a5203d6a97e5">


<!-- 개발 기능을 보여줄 수 있는 이미지, GIF -->

## Precaution

* 기능을 추가하다보니 버튼 부분의 디테일 요소가 필요하다는 생각이 들었습니다.
  * 주차장 버튼이 클릭 되었을 때, 해당 버튼이 클릭 되었다는 active 상태를 보여줄 수 있을 것 같습니다.
  * 선택된 카테고리를 reset될 수 있는 버튼 혹은 토글 방식을 사용하여 카테고리를 해제 할 수 있는 기능을 추가할 수 있을 것 같습니다.
 
이는 추후 기능이 완성되고 그 후의 작업으로 진행하겠습니다.

* 야구장의 위치를 찍는 마커의 위치가 조금 벗어나는 현상이 있습니다. 이는 kakaomap을 사용하는 중에 offset이라는 속성을 통해 수정이 가능하다고 하였으나, 구현에서 잘 진행되지 않았습니다.     
   현재 기능 구현의 우선순위가 높다고 판단되어 이는 후순위로 미루고 pr올리겠습니다. 
<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
